### PR TITLE
使用局部变量，防止共享静态变量引起的状态相互干扰

### DIFF
--- a/laogong/src/main/java/zookeeper/Zk.java
+++ b/laogong/src/main/java/zookeeper/Zk.java
@@ -17,7 +17,7 @@ import java.util.concurrent.locks.Lock;
  * @date: 2020-04-06
  **/
 public class Zk implements Lock {
-    private static CountDownLatch cdl = new CountDownLatch(1);
+    private CountDownLatch cdl = new CountDownLatch(1);
 
     private static final String IP_PORT = "127.0.0.1:2181";
     private static final String Z_NODE = "/LOCK";

--- a/laogong/src/main/java/zookeeper/ZkLock.java
+++ b/laogong/src/main/java/zookeeper/ZkLock.java
@@ -9,7 +9,7 @@ public class ZkLock implements Runnable {
     static int inventory = 10;
     private static final int NUM = 5;
 
-    private static Zk zk = new Zk();
+//    private static Zk zk = new Zk();
 
     public static void main(String[] args) {
         try {
@@ -17,6 +17,7 @@ public class ZkLock implements Runnable {
             for (int i = 0; i < NUM; i++) {
                 new Thread(new Runnable() {
                     public void run() {
+                        Zk zk = new Zk();
                         try {
                             zk.lock();
                             Thread.sleep(1000);


### PR DESCRIPTION
Zk中的CountDownLatch改为非静态变量，防止不同节点之间通知相互干扰；
使用方（ZkLock）中每次使用都创建局部变量，如果使用同一个对象的话，Lock中的path、beforePath等属性也相互干扰